### PR TITLE
implements throwing error for unresolved dependecies

### DIFF
--- a/src/tasks/rollupJS.js
+++ b/src/tasks/rollupJS.js
@@ -37,6 +37,15 @@ export default async (
 			isProd() && cleanup({ ...options.cleanupOptions }),
 			isProd() && terser(),
 		],
+		onwarn(warning, warn) {
+			if (warning.code === 'UNRESOLVED_IMPORT') {
+				const message = `'${warning.source}' is imported by ${warning.importer}, but could not be resolved. If this is an external dependency (https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency) - please add it to inputOptions.external (https://rollupjs.org/guide/en/#external)`;
+				throw new Error(message);
+			}
+
+			// Use default for everything else
+			warn(warning);
+		},
 		...options.inputOptions,
 	};
 	const outputOptions = {


### PR DESCRIPTION
closes #4

I did not add a specific feature flag to enable or disable this behaviour. But it is quite easy to change the behaviour back to normal by injecting the default “onwarn” callback to input options:

```javascript
inputOptions: {
	onwarn(warning, warn) {
		warn(warning);
	},
},
```