### PR TITLE
feat(rollup): brings back rollup watchmode <3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## [0.5.1] - 2021-04-30
+
+### ADDED
+
+-   adds an optional watch mode to js task. It will be enabled by default in dev environments. It can be disabled by passing watchOptions = false if a custom watch is preffered
+
 ## [0.5.0] - 2021-04-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webtides/tasks",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Tasks is a wrapper around gulp for most of the use cases for simple and modern (frontend) web development ",
 	"keywords": [
 		"tasks",


### PR DESCRIPTION
I was super unhappy with the bundling speed and realized that manual watching and restarting rollup on every change actually bypasses one of its most important fetaures.

Watch will be enabled by default but can e disabled via watchOptions